### PR TITLE
Add Python 3 to the Conda environment, because make serve needs it

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - gxx_linux-64
+  - python=3
   - rb-nokogiri
   - ruby


### PR DESCRIPTION
Python 3 is required to serve the site locally from a conda environment:
https://github.com/ESMValGroup/tutorial/blob/79ae749dc2f64e8f4ca3381412ddd69e90a30274/Makefile#L29

With this change I was able to serve the notebook on `jasmin-sci4`, using these commands:
```bash
git clone https://github.com/esmvalgroup/tutorial
cd tutorial
conda env create
conda activate esmvaltool_tutorial
make serve
```
