### PR TITLE
Fixed typoes and indentation issues in chapters 1-5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Episodes are [Markdown](https://en.wikipedia.org/wiki/Markdown) files. If you
 are making a new episode or contributing to existing ones, please make sure the
 content conforms to the [Carpentries lesson formatting][swc-lesson-formatting].
 
-We also, recommend using a linter to check errors in Markdown files. For
+We also recommend using a linter to check errors in Markdown files. For
 example, a
 [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
 can be installed as an extension in [Visual Studio

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -45,7 +45,7 @@ technical steps, let's talk about what ESMValTool is all about.
 ESMValTool takes care of finding, opening, checking, fixing, concatenating, and
 preprocessing CMIP data and several other supported datasets.
 
-The central componnent of ESMValTool that we will see in this tutorial is the
+The central component of ESMValTool that we will see in this tutorial is the
 **recipe**. Any ESMValTool recipe is basically a set of instructions to reproduce
 a certain result. The basic structure of a recipe is as follows:
 

--- a/_episodes/02-installation.md
+++ b/_episodes/02-installation.md
@@ -19,7 +19,7 @@ The instructions help with the installation of ESMValTool on operating systems
 like Linux/MacOSX/Windows.
 We use the [Conda](https://conda.io/projects/conda/en/latest/index.html)
 package manager to
-install the ESMValTool. Other installation methods are also available, they can
+install the ESMValTool. Other installation methods are also available; they can
 be found in the
 [documentation](https://docs.esmvaltool.org/en/latest/quickstart/installation.html).
 We will first install Conda, and then ESMValTool. We end this chapter by testing

--- a/_episodes/03-configuration.md
+++ b/_episodes/03-configuration.md
@@ -71,9 +71,12 @@ For example, `write_plots: true` means that diagnostics create plots.
 
 > ## Saving preprocessed data
 >
-> Later in this tutorial, we will want to look at the contents of the `preproc` folder.
-> This folder contains preprocessed data and is removed by default when ESMValTool is run.
-> In the configuration file, which settings can be modified to prevent this from happening?
+> Later in this tutorial, we will want to look at the contents of the
+> `preproc` folder.
+> This folder contains preprocessed data and is removed by default when
+> ESMValTool is run.
+> In the configuration file, which settings can be modified to prevent
+> this from happening?
 >
 >> ## Solution
 >>
@@ -89,10 +92,11 @@ For example, `write_plots: true` means that diagnostics create plots.
 
 ## Destination directory
 
-The destination directory is the rootpath where ESMValTool will store its output folders containing
-e.g. figures, data, logs, etc. With every run, ESMValTool automatically generates
-a new output folder determined by recipe name, and date and time using
-the format: YYYYMMDD_HHMMSS.
+The destination directory is the rootpath where ESMValTool will store its
+output folders containing
+e.g. figures, data, logs, etc. With every run, ESMValTool automatically
+generates a new output folder determined by recipe name, and date and time
+using the format: YYYYMMDD_HHMMSS.
 
 > ## Set the destination directory
 >
@@ -153,28 +157,29 @@ example configuration file.
 >>   You need to add the root path of the folder where the data is available
 >> to the `config-user.yml` file as:
 >>```yaml
->>  rootpath:
->>  ...
->>    CMIP5: ~/esmvaltool_tutorial/data
->>    CMIP6: ~/esmvaltool_tutorial/data
+>>   rootpath:
+>>   ...
+>>     CMIP5: ~/esmvaltool_tutorial/data
+>>     CMIP6: ~/esmvaltool_tutorial/data
 >>```
 >>
 >> - Are you working with on a computer cluster like Jasmin or DKRZ?
 >>   Site-specific path to the data are already listed at the end of the
 >> `config-user.yml` file. You need to uncomment the related lines.
 >> For example, on Jasmin:
+>>
 >>```yaml
->>  # Site-specific entries: Jasmin
->>  # Uncomment the lines below to locate data on JASMIN
->>  rootpath:
->>    CMIP6: /badc/cmip6/data/CMIP6
->>    CMIP5: /badc/cmip5/data/cmip5/output1
->>  #  CMIP3: /badc/cmip3_drs/data/cmip3/output
->>  #  OBS: /group_workspaces/jasmin4/esmeval/obsdata-v2
->>  #  OBS6: /group_workspaces/jasmin4/esmeval/obsdata-v2
->>  #  obs4mips: /group_workspaces/jasmin4/esmeval/obsdata-v2
->>  #  ana4mips: /group_workspaces/jasmin4/esmeval/obsdata-v2
->>  #  CORDEX: /badc/cordex/data/CORDEX/output
+>>   # Site-specific entries: Jasmin
+>>   # Uncomment the lines below to locate data on JASMIN
+>>   rootpath:
+>>     CMIP6: /badc/cmip6/data/CMIP6
+>>     CMIP5: /badc/cmip5/data/cmip5/output1
+>>   #  CMIP3: /badc/cmip3_drs/data/cmip3/output
+>>   #  OBS: /group_workspaces/jasmin4/esmeval/obsdata-v2
+>>   #  OBS6: /group_workspaces/jasmin4/esmeval/obsdata-v2
+>>   #  obs4mips: /group_workspaces/jasmin4/esmeval/obsdata-v2
+>>   #  ana4mips: /group_workspaces/jasmin4/esmeval/obsdata-v2
+>>   #  CORDEX: /badc/cordex/data/CORDEX/output
 >>```
 >>
 >> - For more information about setting the rootpath, see also the ESMValTool
@@ -217,17 +222,17 @@ information about ``drs``, you can visit the ESMValTool documentation on
 >> `config-user.yml` file. You need to uncomment the related lines.
 >> For example, on Jasmin:
 >>```yaml
->>  # Site-specific entries: Jasmin
->>  # Uncomment the lines below to locate data on JASMIN
->>  drs:
->>    CMIP6: BADC
->>    CMIP5: BADC
->>  #  CMIP3: BADC
->>  #  CORDEX: BADC
->>  #  OBS: BADC
->>  #  OBS6: BADC
->>  #  obs4mips: BADC
->>  #  ana4mips: BADC
+>>   # Site-specific entries: Jasmin
+>>   # Uncomment the lines below to locate data on JASMIN
+>>   drs:
+>>     CMIP6: BADC
+>>     CMIP5: BADC
+>>   #  CMIP3: BADC
+>>   #  CORDEX: BADC
+>>   #  OBS: BADC
+>>   #  OBS6: BADC
+>>   #  obs4mips: BADC
+>>   #  ana4mips: BADC
 >>```
 >>
 > {: .solution}
@@ -236,10 +241,10 @@ information about ``drs``, you can visit the ESMValTool documentation on
 > ## Explain the default drs (if working on local machine)
 >
 > 1. In the previous exercise, we set the `drs` of CMIP5 data to `default`.
-> Can you explain why?
->
+>    Can you explain why?
+
 > 2. Have a look at the directory structure of the data.
-> There is the folder `Tier1`. What does it mean?
+>    There is the folder `Tier1`. What does it mean?
 >
 >> ## Solution
 >>
@@ -288,7 +293,8 @@ the tutorial, please set ESMValTool use only 1 cpu:
 Then, check the amount of memory you need for that by inspecting the file
 ``run/resource_usage.txt`` in the output directory. Using the number there you
 can increase the number of parallel tasks again to a reasonable number for the
-amount of memory available in your system. {: .callout}
+amount of memory available in your system.
+{: .callout}
 
 > ## Make your own configuration file
 >

--- a/_episodes/03-configuration.md
+++ b/_episodes/03-configuration.md
@@ -242,7 +242,6 @@ information about ``drs``, you can visit the ESMValTool documentation on
 >
 > 1. In the previous exercise, we set the `drs` of CMIP5 data to `default`.
 >    Can you explain why?
-
 > 2. Have a look at the directory structure of the data.
 >    There is the folder `Tier1`. What does it mean?
 >

--- a/_episodes/04-recipe.md
+++ b/_episodes/04-recipe.md
@@ -239,7 +239,7 @@ distinguished in the log messages:
 > > Just after 'creating tasks' and before 'executing tasks', we find the
 > > following line in the output:
 > >
-> > ```sh
+> > ```
 > > INFO    [29586] These tasks will be executed: timeseries/tas_global, timeseries/tas_amsterdam, map/tas, map/script1, timeseries/script1
 > > ```
 > >
@@ -427,7 +427,7 @@ Do you recognize the basic recipe structure that was introduced in episode 1?
 > `tas_global`. Both of them operate on the variable `tas` (as indicated by the
 > `short_name`), but they apply different preprocessors. For the diagnostic
 > `map` the variable group itself is named `tas`, and you'll notice that we do
-> not explicitly provide the `short_name`. This is a shorthand build into
+> not explicitly provide the `short_name`. This is a shorthand built into
 > ESMValTool.
 {: .callout}
 


### PR DESCRIPTION
This PR fixes issue #170 by correcting the indentation in an answer block, and also fixes a number of small typoes, linting, and formatting issues in the first few chapters.


## Tasks

- [x] Give this pull request a descriptive title.
- [ ] If you are contributing to existing lesson materials, please make sure the content conforms to the `Lesson development` section in [CONTRIBUTING.md](https://github.com/ESMValGroup/tutorial/blob/master/CONTRIBUTING.md) and does not contain any spelling or grammatical errors.
- [ ] If you are making a new episode, please make sure the content conforms to the `Lesson organization` and `Lesson formatting` sections in [CONTRIBUTING.md](https://github.com/ESMValGroup/tutorial/blob/master/CONTRIBUTING.md) and does not contain any spelling or grammatical errors.
- [ ] Preferably Codacy checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why.
- [x] Preview changes on your machine before pushing them to GitHub by running `make serve`, alternatively `make docker-serve`. Please see the `Previewing your changes locally` section in [CONTRIBUTING.md](https://github.com/ESMValGroup/tutorial/blob/master/CONTRIBUTING.md) for installation instructions.
- [ ] All code instructions have been tested.

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #170 