### PR TITLE
Fix recipe name in episode 5

### DIFF
--- a/_episodes/04-recipe.md
+++ b/_episodes/04-recipe.md
@@ -374,7 +374,7 @@ Let's make a small modification to the example recipe. Notice that now that
 you have copied and edited the recipe, you can use
 
 ```
-esmvaltool run recipe_example.yml
+esmvaltool run recipe_python.yml
 ```
 
 to refer to your local file rather than the default version shipped with


### PR DESCRIPTION
This PR fixes the recipe name in epside "5. Running your first recipe". The recipe name in the section "Modifying the example recipe" is changed to the original name `recipe_python.yml`.

Closes #272 
