### PR TITLE
Add ESGF config file for versions v2.6 and v2.7

### DIFF
--- a/files/esgf-pyclient.yml
+++ b/files/esgf-pyclient.yml
@@ -1,4 +1,4 @@
-# If you're using ESMValTool 2.4.0 to 2.7.0, you can copy this file to
+# If you're using ESMValTool 2.6.0 or 2.7.0, you can copy this file to
 # ~/.esmvaltool/esgf-pyclient.yml to use the current URL for the CEDA ESGF
 # index node. See
 # https://docs.esmvaltool.org/projects/ESMValCore/en/v2.7.0/quickstart/configure.html#configuration-file

--- a/files/esgf-pyclient.yml
+++ b/files/esgf-pyclient.yml
@@ -1,0 +1,15 @@
+# If you're using ESMValTool 2.4.0 to 2.7.0, you can copy this file to
+# ~/.esmvaltool/esgf-pyclient.yml to use the current URL for the CEDA ESGF
+# index node. See
+# https://docs.esmvaltool.org/projects/ESMValCore/en/v2.7.0/quickstart/configure.html#configuration-file
+# for more information on the use of this file.
+search_connection:
+  urls:
+    - 'https://esgf.ceda.ac.uk/esg-search'
+    - 'https://esgf-node.llnl.gov/esg-search'
+    - 'https://esgf-data.dkrz.de/esg-search'
+    - 'https://esgf-node.ipsl.upmc.fr/esg-search'
+    - 'https://esg-dn1.nsc.liu.se/esg-search'
+    - 'https://esgf.nci.org.au/esg-search'
+    - 'https://esgf.nccs.nasa.gov/esg-search'
+    - 'https://esgdata.gfdl.noaa.gov/esg-search'


### PR DESCRIPTION
The index node http://esgf-index1.ceda.ac.uk/esg-search has been retired (the new URL is https://esgf.ceda.ac.uk/esg-search) and this was the URL that ESMValCore versions 2.6 and v2.7 used by default to search ESGF. Unfortunately fallback to alternative index nodes was not available or did not work correctly either for these older versions. Therefore this pull request adds an updated `~/.esmvaltool/esgf-pyclient.yml` file so older versions of the tool can still be used with ESGF search functionality.

In versions 2.4 and 2.5 a different format for this configuration file was used. For those versions, the file with the updated configuration should look like
```yaml
search_connection:
  url: "https://esgf.ceda.ac.uk/esg-search"
```

I did not add that here because it may be confusing and I'm not sure if it's still relevant.
